### PR TITLE
Automatically locate datasets from examples

### DIFF
--- a/examples/atomneb_chianti60_example.pro
+++ b/examples/atomneb_chianti60_example.pro
@@ -3,10 +3,12 @@
 
 ; Use Atomic Data from the CHIANTI atomic database version 6.0
 
-; Update paths!
-Atom_Elj_file='/home/atomic_data/atomneb/atomic-data/chianti60/AtomElj.fits'
-Atom_Omij_file='/home/atomic_data/atomneb/atomic-data/chianti60/AtomOmij.fits'
-Atom_Aij_file='/home/atomic_data/atomneb/atomic-data/chianti60/AtomAij.fits'
+; Locate datasets
+base_dir = file_dirname(file_dirname((routine_info('$MAIN$', /source)).path))
+examples = ['atomic-data', 'chianti60']
+Atom_Elj_file = filepath('AtomElj.fits', root_dir=base_dir, subdir=examples)
+Atom_Omij_file = filepath('AtomOmij.fits', root_dir=base_dir, subdir=examples)
+Atom_Aij_file = filepath('AtomAij.fits', root_dir=base_dir, subdir=examples)
 
 ; read Energy Levels (Ej) list
 elj_data_list=atomneb_read_elj_list(Atom_Elj_file)


### PR DESCRIPTION
This PR contains a change that lets IDL automatically find the FITS datasets that accompany this package from the examples in which they're used.

There are positive aspects to this change:

+ users won't have to manually modify the paths to the datasets
+ platform independence (even works on Windows)

and negative aspects:

- the code isn't easy to understand
- it introduces a version dependency (IDL >= 6.0)

For these reasons, I offer this PR only as a suggestion, and I changed just one of the examples. If this change looks useful, the same idea (and similar code) could be applied to all the examples.